### PR TITLE
Replace SmallVec with ArrayVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/ridi/isbn-rs"
 edition = "2018"
 
 [dependencies]
-smallvec = { version = "0.6", default-features = false }
+arrayvec = { version = "0.4", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,9 +265,9 @@ impl Parser {
         let check_digit = Isbn13::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
             let d = &self.digits;
-            Ok(Isbn13::new(
+            Isbn13::new(
                 d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10], d[11], d[12],
-            ))
+            )
         } else {
             Err(IsbnError::InvalidDigit)
         }
@@ -277,9 +277,9 @@ impl Parser {
         let check_digit = Isbn10::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
             let d = &self.digits;
-            Ok(Isbn10::new(
+            Isbn10::new(
                 d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9],
-            ))
+            )
         } else {
             Err(IsbnError::InvalidDigit)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 use core::fmt;
 use core::num::ParseIntError;
 use core::str::FromStr;
-use smallvec::SmallVec;
+use arrayvec::ArrayVec;
 
 pub type IsbnResult<T> = Result<T, IsbnError>;
 
@@ -186,9 +186,9 @@ impl fmt::Display for Isbn13 {
 
 impl From<Isbn10> for Isbn13 {
     fn from(isbn10: Isbn10) -> Isbn13 {
-        let mut v = SmallVec::<[u8; 13]>::new();
-        v.extend_from_slice(&[9, 7, 8]);
-        v.extend_from_slice(&isbn10.digits[..9]);
+        let mut v = ArrayVec::<[u8; 13]>::new();
+        v.extend([9, 7, 8].iter().cloned());
+        v.extend(isbn10.digits[..9].iter().cloned());
         let c = Isbn13::calculate_check_digit(&v);
         let d = isbn10.digits;
         Isbn13::new(
@@ -224,7 +224,7 @@ impl From<ParseIntError> for IsbnError {
 
 #[derive(Debug, Clone)]
 struct Parser {
-    digits: SmallVec<[u8; 13]>,
+    digits: ArrayVec<[u8; 13]>,
 }
 
 impl Parser {


### PR DESCRIPTION
Replace SmallVec with ArrayVec as it don't use a feature gate.