### PR TITLE
Add hyphenation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ description = "A library for handling ISBNs."
 license = "MIT"
 repository = "https://github.com/ridi/isbn-rs"
 edition = "2018"
+
+[build-dependencies]
+codegen = "0.1"
+roxmltree = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -83,7 +83,7 @@ fn codegen_find_group(name: &str, groups: Vec<Group>) -> Function {
     let mut fn_get_group = Function::new(name);
     fn_get_group.arg("prefix", "&str");
     fn_get_group.arg("segment", "u32");
-    fn_get_group.ret("Result<Group, IsbnError>");
+    fn_get_group.ret("Result<Group<'static>, IsbnError>");
 
     let mut match_prefix = Block::new("match prefix");
     for group in groups {
@@ -103,7 +103,7 @@ fn codegen_find_group(name: &str, groups: Vec<Group>) -> Function {
         let_length_eq_match_segment.after(";");
 
         let mut ok_group = Block::new("Ok(Group");
-        ok_group.line(format!("agency: \"{}\".to_string(),", group.agency));
+        ok_group.line(format!("agency: \"{}\",", group.agency));
         ok_group.line("segment_length: length?");
         ok_group.after(")");
 

--- a/build.rs
+++ b/build.rs
@@ -6,19 +6,21 @@ use std::path::Path;
 use codegen::{Block, Function, Scope};
 use roxmltree::{Document, Node};
 
+/// EAN.UCC prefix or registration group.
 struct Group {
     agency: String,
     prefix: String,
     rules: Vec<Rule>,
 }
 
+/// Range length rule.
 struct Rule {
     min: u32,
     max: u32,
     length: usize,
 }
 
-/// Parse Registration Group and Registrant range length rules.
+/// Parse registration group and registrant range length rules.
 fn parse_rules(group: Node) -> Vec<Rule> {
     group
         .descendants()
@@ -52,7 +54,7 @@ fn parse_rules(group: Node) -> Vec<Rule> {
         .collect()
 }
 
-/// Parse EAN.UCC and Registration Group element.
+/// Parse EAN.UCC prefix and registration group element.
 fn parse_group(group: Node) -> Group {
     let prefix = group
         .descendants()
@@ -77,6 +79,7 @@ fn parse_group(group: Node) -> Group {
     }
 }
 
+/// Generate code for EAN.UCC or registration group lookup.
 fn codegen_find_group(name: &str, groups: Vec<Group>) -> Function {
     let mut fn_get_group = Function::new(name);
     fn_get_group.arg("prefix", "&str");

--- a/build.rs
+++ b/build.rs
@@ -6,14 +6,12 @@ use std::path::Path;
 use codegen::{Block, Function, Scope};
 use roxmltree::{Document, Node};
 
-#[derive(Clone)]
 struct Group {
     agency: String,
     prefix: String,
     rules: Vec<Rule>,
 }
 
-#[derive(Clone)]
 struct Rule {
     min: u32,
     max: u32,

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,152 @@
+use std::env;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use codegen::{Block, Function, Scope};
+use roxmltree::{Document, Node};
+
+#[derive(Clone)]
+struct Group {
+    agency: String,
+    prefix: String,
+    rules: Vec<Rule>,
+}
+
+#[derive(Clone)]
+struct Rule {
+    min: u32,
+    max: u32,
+    length: usize,
+}
+
+/// Parse Registration Group and Registrant range length rules.
+fn parse_rules(group: Node) -> Vec<Rule> {
+    group
+        .descendants()
+        .filter(|n| n.has_tag_name("Rule"))
+        .map(|r| {
+            let range: Vec<u32> = r
+                .descendants()
+                .find(|n| n.has_tag_name("Range"))
+                .unwrap()
+                .text()
+                .unwrap()
+                .split('-')
+                .map(|i| i.parse().unwrap())
+                .collect();
+
+            let length = r
+                .descendants()
+                .find(|n| n.has_tag_name("Length"))
+                .unwrap()
+                .text()
+                .unwrap()
+                .parse()
+                .unwrap();
+
+            Rule {
+                min: range[0],
+                max: range[1],
+                length: length,
+            }
+        })
+        .collect()
+}
+
+/// Parse EAN.UCC and Registration Group element.
+fn parse_group(group: Node) -> Group {
+    let prefix = group
+        .descendants()
+        .find(|n| n.has_tag_name("Prefix"))
+        .unwrap()
+        .text()
+        .unwrap()
+        .to_string();
+
+    let agency = group
+        .descendants()
+        .find(|n| n.has_tag_name("Agency"))
+        .unwrap()
+        .text()
+        .unwrap()
+        .to_string();
+
+    Group {
+        agency: agency,
+        prefix: prefix,
+        rules: parse_rules(group),
+    }
+}
+
+fn codegen_find_group(name: &str, groups: Vec<Group>) -> Function {
+    let mut fn_get_group = Function::new(name);
+    fn_get_group.arg("prefix", "&str");
+    fn_get_group.arg("segment", "u32");
+    fn_get_group.ret("Result<Group, IsbnError>");
+
+    let mut match_prefix = Block::new("match prefix");
+    for group in groups {
+        match_prefix.line(format!("\"{}\" =>", group.prefix));
+
+        let mut let_length_eq_match_segment = Block::new("let length = match segment");
+        for rule in &group.rules {
+            let_length_eq_match_segment.line(match rule.length {
+                0 => format!(
+                    "{} ... {} => Err(IsbnError::UndefinedRange),",
+                    rule.min, rule.max
+                ),
+                _ => format!("{} ... {} => Ok({}),", rule.min, rule.max, rule.length),
+            });
+        }
+        let_length_eq_match_segment.line("_ => Err(IsbnError::InvalidGroup)");
+        let_length_eq_match_segment.after(";");
+
+        let mut ok_group = Block::new("Ok(Group");
+        ok_group.line(format!("agency: \"{}\".to_string(),", group.agency));
+        ok_group.line("segment_length: length?");
+        ok_group.after(")");
+
+        let mut segment_match_block = Block::new("");
+        segment_match_block.push_block(let_length_eq_match_segment);
+        segment_match_block.push_block(ok_group);
+
+        match_prefix.push_block(segment_match_block);
+    }
+    match_prefix.line("_ => Err(IsbnError::InvalidGroup)");
+
+    fn_get_group.push_block(match_prefix);
+    fn_get_group
+}
+
+fn main() {
+    let mut f = File::open("isbn-ranges/RangeMessage.xml").unwrap();
+    let mut text = String::new();
+    f.read_to_string(&mut text).unwrap();
+
+    let range_message = Document::parse(&text).unwrap();
+    let ean_ucc_groups = range_message
+        .descendants()
+        .filter(|d| d.tag_name().name() == "EAN.UCC")
+        .map(|g| parse_group(g))
+        .collect();
+    let registration_groups = range_message
+        .descendants()
+        .filter(|d| d.tag_name().name() == "Group")
+        .map(|g| parse_group(g))
+        .collect();
+
+    let mut scope = Scope::new();
+    let impl_isbn = scope.new_impl("Isbn");
+    impl_isbn.push_fn(codegen_find_group("get_ean_ucc_group", ean_ucc_groups));
+    impl_isbn.push_fn(codegen_find_group(
+        "get_registration_group",
+        registration_groups,
+    ));
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("generated.rs");
+
+    let mut f = File::create(&dest_path).unwrap();
+    f.write_all(scope.to_string().as_bytes()).unwrap();
+}

--- a/build.rs
+++ b/build.rs
@@ -103,7 +103,7 @@ fn codegen_find_group(name: &str, groups: Vec<Group>) -> Function {
         let_length_eq_match_segment.after(";");
 
         let mut ok_group = Block::new("Ok(Group");
-        ok_group.line(format!("agency: \"{}\",", group.agency));
+        ok_group.line(format!("name: \"{}\",", group.agency));
         ok_group.line("segment_length: length?");
         ok_group.after(")");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,19 +56,19 @@ struct Group<'a> {
 
 impl Isbn {
     /// Hyphenate an ISBN into its parts:
-    /// 
+    ///
     /// * GS1 Prefix (ISBN-13 only)
     /// * Registration group
     /// * Registrant
     /// * Publication
     /// * Check digit
-    /// 
+    ///
     /// ```
     /// use isbn::{Isbn, Isbn10, Isbn13};
     ///
     /// let isbn_10 = Isbn::_10(Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap());
     /// let isbn_13 = Isbn::_13(Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap());
-    /// 
+    ///
     /// assert_eq!(isbn_10.hyphenate().unwrap().as_str(), "89-6626-126-4");
     /// assert_eq!(isbn_13.hyphenate().unwrap().as_str(), "978-1-4920-6766-5");
     /// ```
@@ -80,13 +80,13 @@ impl Isbn {
     }
 
     /// Retrieve the name of the registration group.
-    /// 
+    ///
     /// ```
     /// use isbn::{Isbn, Isbn10, Isbn13};
-    /// 
+    ///
     /// let isbn_10 = Isbn::_10(Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap());
     /// let isbn_13 = Isbn::_13(Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap());
-    /// 
+    ///
     /// assert_eq!(isbn_10.registration_group(), Ok("Korea, Republic"));
     /// assert_eq!(isbn_13.registration_group(), Ok("English language"));
     /// ```
@@ -204,15 +204,15 @@ impl Isbn10 {
     }
 
     /// Hyphenate an ISBN-10 into its parts:
-    /// 
+    ///
     /// * Registration group
     /// * Registrant
     /// * Publication
     /// * Check digit
-    /// 
+    ///
     /// ```
     /// use isbn::Isbn10;
-    /// 
+    ///
     /// let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap();
     /// assert_eq!(isbn_10.hyphenate().unwrap().as_str(), "89-6626-126-4");
     /// ```
@@ -234,10 +234,10 @@ impl Isbn10 {
     }
 
     /// Retrieve the name of the registration group.
-    /// 
+    ///
     /// ```
     /// use isbn::Isbn10;
-    /// 
+    ///
     /// let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap();
     /// assert_eq!(isbn_10.registration_group(), Ok("Korea, Republic"));
     /// ```
@@ -341,16 +341,16 @@ impl Isbn13 {
     }
 
     /// Hyphenate an ISBN-13 into its parts:
-    /// 
+    ///
     /// * GS1 Prefix
     /// * Registration group
     /// * Registrant
     /// * Publication
     /// * Check digit
-    /// 
+    ///
     /// ```
     /// use isbn::Isbn13;
-    /// 
+    ///
     /// let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap();
     /// assert_eq!(isbn_13.hyphenate().unwrap().as_str(), "978-1-4920-6766-5");
     /// ```
@@ -372,10 +372,10 @@ impl Isbn13 {
     }
 
     /// Retrieve the name of the registration group.
-    /// 
+    ///
     /// ```
     /// use isbn::Isbn13;
-    /// 
+    ///
     /// let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap();
     /// assert_eq!(isbn_13.registration_group(), Ok("English language"));
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,13 @@
 //! use isbn::{Isbn10, Isbn13};
 //!
 //! let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4);
+//! assert_eq!(isbn_10.hyphenate(), Ok("89-6626-126-4".to_string()));
+//! assert_eq!(isbn_10.agency(), Ok("Korea, Republic".to_string()));
 //! assert_eq!("89-6626-126-4".parse(), Ok(isbn_10));
 //!
 //! let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5);
+//! assert_eq!(isbn_13.hyphenate(), Ok("978-1-4920-6766-5".to_string()));
+//! assert_eq!(isbn_13.agency(), Ok("English language".to_string()));
 //! assert_eq!("978-1-4920-6766-5".parse(), Ok(isbn_13));
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,9 +418,7 @@ impl Parser {
         let check_digit = Isbn10::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
             let d = &self.digits;
-            Isbn10::new(
-                d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9],
-            )
+            Isbn10::new(d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9])
         } else {
             Err(IsbnError::InvalidDigit)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ impl Isbn13 {
     }
 
     fn ean_ucc_group(&self) -> Result<Group, IsbnError> {
-        let mut s = ArrayString::<[u8; 100]>::new();
+        let mut s = ArrayString::<[u8; 3]>::new();
         for i in 0..3 {
             s.push(char::from_digit(self.digits[i].into(), 10).unwrap());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! # Examples
 //!
 //! ```
-//! use isbn::{Isbn, Isbn10, Isbn13};
+//! use isbn::{Isbn10, Isbn13};
 //!
 //! let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap();
 //! assert_eq!(isbn_10.hyphenate().unwrap().as_str(), "89-6626-126-4");
@@ -180,7 +180,6 @@ impl Isbn10 {
     /// use isbn::{Isbn10, Isbn13};
     ///
     /// let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap();
-    ///
     /// assert_eq!(Isbn10::try_from(isbn_13), "1-4920-6766-0".parse());
     /// ```
     pub fn try_from(isbn13: Isbn13) -> IsbnResult<Self> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,6 @@ impl Isbn10 {
             self.digits.get(base + 5).unwrap_or(&0),
             self.digits.get(base + 6).unwrap_or(&0),
         );
-        println!("{}", s);
         s.parse().unwrap()
     }
 
@@ -334,7 +333,6 @@ impl Isbn13 {
             self.digits.get(base + 8).unwrap_or(&0),
             self.digits.get(base + 9).unwrap_or(&0),
         );
-        println!("{}", s);
         s.parse().unwrap()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,23 @@ struct Group<'a> {
 }
 
 impl Isbn {
+    /// Hyphenate an ISBN into its parts:
+    /// 
+    /// * GS1 Prefix (ISBN-13 only)
+    /// * Registration group
+    /// * Registrant
+    /// * Publication
+    /// * Check digit
+    /// 
+    /// ```
+    /// use isbn::{Isbn, Isbn10, Isbn13};
+    ///
+    /// let isbn_10 = Isbn::_10(Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap());
+    /// let isbn_13 = Isbn::_13(Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap());
+    /// 
+    /// assert_eq!(isbn_10.hyphenate().unwrap().as_str(), "89-6626-126-4");
+    /// assert_eq!(isbn_13.hyphenate().unwrap().as_str(), "978-1-4920-6766-5");
+    /// ```
     pub fn hyphenate(&self) -> Result<ArrayString<[u8; 17]>, IsbnError> {
         match *self {
             Isbn::_10(ref c) => c.hyphenate(),
@@ -62,6 +79,17 @@ impl Isbn {
         }
     }
 
+    /// Retrieve the name of the registration group.
+    /// 
+    /// ```
+    /// use isbn::{Isbn, Isbn10, Isbn13};
+    /// 
+    /// let isbn_10 = Isbn::_10(Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap());
+    /// let isbn_13 = Isbn::_13(Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap());
+    /// 
+    /// assert_eq!(isbn_10.registration_group(), Ok("Korea, Republic"));
+    /// assert_eq!(isbn_13.registration_group(), Ok("English language"));
+    /// ```
     pub fn registration_group(&self) -> Result<&str, IsbnError> {
         match *self {
             Isbn::_10(ref c) => c.registration_group(),
@@ -176,6 +204,19 @@ impl Isbn10 {
         check_digit as u8
     }
 
+    /// Hyphenate an ISBN-10 into its parts:
+    /// 
+    /// * Registration group
+    /// * Registrant
+    /// * Publication
+    /// * Check digit
+    /// 
+    /// ```
+    /// use isbn::Isbn10;
+    /// 
+    /// let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap();
+    /// assert_eq!(isbn_10.hyphenate().unwrap().as_str(), "89-6626-126-4");
+    /// ```
     pub fn hyphenate(&self) -> Result<ArrayString<[u8; 17]>, IsbnError> {
         let registration_group_segment_length =
             Isbn::get_ean_ucc_group("978", self.segment(0))?.segment_length;
@@ -193,6 +234,14 @@ impl Isbn10 {
         Ok(hyphenate(&self.digits, &hyphen_at))
     }
 
+    /// Retrieve the name of the registration group.
+    /// 
+    /// ```
+    /// use isbn::Isbn10;
+    /// 
+    /// let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap();
+    /// assert_eq!(isbn_10.registration_group(), Ok("Korea, Republic"));
+    /// ```
     pub fn registration_group(&self) -> Result<&str, IsbnError> {
         let registration_group_segment_length =
             Isbn::get_ean_ucc_group("978", self.segment(0))?.segment_length;
@@ -292,6 +341,20 @@ impl Isbn13 {
         Isbn::get_ean_ucc_group(&s, self.segment(0))
     }
 
+    /// Hyphenate an ISBN-13 into its parts:
+    /// 
+    /// * GS1 Prefix
+    /// * Registration group
+    /// * Registrant
+    /// * Publication
+    /// * Check digit
+    /// 
+    /// ```
+    /// use isbn::Isbn13;
+    /// 
+    /// let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap();
+    /// assert_eq!(isbn_13.hyphenate().unwrap().as_str(), "978-1-4920-6766-5");
+    /// ```
     pub fn hyphenate(&self) -> Result<ArrayString<[u8; 17]>, IsbnError> {
         let registration_group_segment_length = self.ean_ucc_group()?.segment_length;
         let registrant_segment_length = Isbn::get_registration_group(
@@ -309,6 +372,14 @@ impl Isbn13 {
         Ok(hyphenate(&self.digits, &hyphen_at))
     }
 
+    /// Retrieve the name of the registration group.
+    /// 
+    /// ```
+    /// use isbn::Isbn13;
+    /// 
+    /// let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap();
+    /// assert_eq!(isbn_13.registration_group(), Ok("English language"));
+    /// ```
     pub fn registration_group(&self) -> Result<&str, IsbnError> {
         let registration_group_segment_length = self.ean_ucc_group()?.segment_length;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,17 +180,11 @@ impl Isbn10 {
     }
 
     fn segment(&self, base: usize) -> u32 {
-        let s = format!(
-            "{}{}{}{}{}{}{}",
-            self.digits.get(base).unwrap_or(&0),
-            self.digits.get(base + 1).unwrap_or(&0),
-            self.digits.get(base + 2).unwrap_or(&0),
-            self.digits.get(base + 3).unwrap_or(&0),
-            self.digits.get(base + 4).unwrap_or(&0),
-            self.digits.get(base + 5).unwrap_or(&0),
-            self.digits.get(base + 6).unwrap_or(&0),
-        );
-        s.parse().unwrap()
+        let mut s = 0;
+        for i in 0..7 {
+            s += (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(6 - i as u32)
+        }
+        s
     }
 
     fn group_prefix(&self, length: usize) -> String {
@@ -323,17 +317,11 @@ impl Isbn13 {
     }
 
     fn segment(&self, base: usize) -> u32 {
-        let s = format!(
-            "{}{}{}{}{}{}{}",
-            self.digits.get(base + 3).unwrap_or(&0),
-            self.digits.get(base + 4).unwrap_or(&0),
-            self.digits.get(base + 5).unwrap_or(&0),
-            self.digits.get(base + 6).unwrap_or(&0),
-            self.digits.get(base + 7).unwrap_or(&0),
-            self.digits.get(base + 8).unwrap_or(&0),
-            self.digits.get(base + 9).unwrap_or(&0),
-        );
-        s.parse().unwrap()
+        let mut s = 0;
+        for i in 3..9 {
+            s += (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(9 - i as u32)
+        }
+        s
     }
 
     fn group_prefix(&self, length: usize) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,7 @@ impl Isbn10 {
     }
 
     fn group_prefix(&self, length: usize) -> ArrayString<[u8; 17]> {
-        let isbn_13 = Isbn13::from(*self);
-        isbn_13.group_prefix(length)
+        Isbn13::from(*self).group_prefix(length)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,11 +180,9 @@ impl Isbn10 {
     }
 
     fn segment(&self, base: usize) -> u32 {
-        let mut s = 0;
-        for i in 0..7 {
-            s += (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(6 - i as u32)
-        }
-        s
+        (0..7).fold(0, |s, i| {
+            s + (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(6 - i as u32)
+        })
     }
 
     fn group_prefix(&self, length: usize) -> String {
@@ -317,11 +315,9 @@ impl Isbn13 {
     }
 
     fn segment(&self, base: usize) -> u32 {
-        let mut s = 0;
-        for i in 3..9 {
-            s += (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(9 - i as u32)
-        }
-        s
+        (3..9).fold(0, |s, i| {
+            s + (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(9 - i as u32)
+        })
     }
 
     fn group_prefix(&self, length: usize) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,12 @@
 //!
 //! let isbn_10 = Isbn10::new(8, 9, 6, 6, 2, 6, 1, 2, 6, 4).unwrap();
 //! assert_eq!(isbn_10.hyphenate().unwrap().as_str(), "89-6626-126-4");
-//! assert_eq!(isbn_10.agency(), Ok("Korea, Republic"));
+//! assert_eq!(isbn_10.registration_group(), Ok("Korea, Republic"));
 //! assert_eq!("89-6626-126-4".parse(), Ok(isbn_10));
 //!
 //! let isbn_13 = Isbn13::new(9, 7, 8, 1, 4, 9, 2, 0, 6, 7, 6, 6, 5).unwrap();
 //! assert_eq!(isbn_13.hyphenate().unwrap().as_str(), "978-1-4920-6766-5");
-//! assert_eq!(isbn_13.agency(), Ok("English language"));
+//! assert_eq!(isbn_13.registration_group(), Ok("English language"));
 //! assert_eq!("978-1-4920-6766-5".parse(), Ok(isbn_13));
 //! ```
 //!
@@ -50,7 +50,7 @@ pub enum Isbn {
 }
 
 struct Group<'a> {
-    agency: &'a str,
+    name: &'a str,
     segment_length: usize,
 }
 
@@ -62,10 +62,10 @@ impl Isbn {
         }
     }
 
-    pub fn agency(&self) -> Result<&str, IsbnError> {
+    pub fn registration_group(&self) -> Result<&str, IsbnError> {
         match *self {
-            Isbn::_10(ref c) => c.agency(),
-            Isbn::_13(ref c) => c.agency(),
+            Isbn::_10(ref c) => c.registration_group(),
+            Isbn::_13(ref c) => c.registration_group(),
         }
     }
 }
@@ -193,7 +193,7 @@ impl Isbn10 {
         Ok(hyphenate(&self.digits, &hyphen_at))
     }
 
-    pub fn agency(&self) -> Result<&str, IsbnError> {
+    pub fn registration_group(&self) -> Result<&str, IsbnError> {
         let registration_group_segment_length =
             Isbn::get_ean_ucc_group("978", self.segment(0))?.segment_length;
 
@@ -201,7 +201,7 @@ impl Isbn10 {
             &self.group_prefix(registration_group_segment_length),
             self.segment(registration_group_segment_length),
         )?
-        .agency)
+        .name)
     }
 
     fn segment(&self, base: usize) -> u32 {
@@ -309,14 +309,14 @@ impl Isbn13 {
         Ok(hyphenate(&self.digits, &hyphen_at))
     }
 
-    pub fn agency(&self) -> Result<&str, IsbnError> {
+    pub fn registration_group(&self) -> Result<&str, IsbnError> {
         let registration_group_segment_length = self.ean_ucc_group()?.segment_length;
 
         Ok(Isbn::get_registration_group(
             &self.group_prefix(registration_group_segment_length),
             self.segment(registration_group_segment_length),
         )?
-        .agency)
+        .name)
     }
 
     fn segment(&self, base: usize) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ impl Isbn10 {
 
     fn segment(&self, base: usize) -> u32 {
         (0..7).fold(0, |s, i| {
-            s + (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(6 - i as u32)
+            s + u32::from(*self.digits.get(base + i).unwrap_or(&0)) * 10_u32.pow(6 - i as u32)
         })
     }
 
@@ -391,7 +391,7 @@ impl Isbn13 {
 
     fn segment(&self, base: usize) -> u32 {
         (3..9).fold(0, |s, i| {
-            s + (*self.digits.get(base + i).unwrap_or(&0) as u32) * 10_u32.pow(9 - i as u32)
+            s + u32::from(*self.digits.get(base + i).unwrap_or(&0)) * 10_u32.pow(9 - i as u32)
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,13 +191,9 @@ impl Isbn10 {
         })
     }
 
-    fn group_prefix(&self, length: usize) -> ArrayString<[u8; 100]> {
-        let mut s = ArrayString::<[u8; 100]>::new();
-        s.push_str("978-");
-        for i in 0..length {
-            s.push(char::from_digit(self.digits[i].into(), 10).unwrap());
-        }
-        s
+    fn group_prefix(&self, length: usize) -> ArrayString<[u8; 17]> {
+        let isbn_13 = Isbn13::from(*self);
+        isbn_13.group_prefix(length)
     }
 }
 
@@ -311,16 +307,8 @@ impl Isbn13 {
         })
     }
 
-    fn group_prefix(&self, length: usize) -> ArrayString<[u8; 100]> {
-        let mut s = ArrayString::<[u8; 100]>::new();
-        for i in 0..3 {
-            s.push(char::from_digit(self.digits[i].into(), 10).unwrap());
-        }
-        s.push('-');
-        for i in 3..(3 + length) {
-            s.push(char::from_digit(self.digits[i].into(), 10).unwrap());
-        }
-        s
+    fn group_prefix(&self, length: usize) -> ArrayString<[u8; 17]> {
+        hyphenate(&self.digits[0..length + 3], &[3])
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,14 +55,6 @@ struct Group<'a> {
 }
 
 impl Isbn {
-    /// Returns `true` if this is a valid ISBN code.
-    pub fn is_valid(&self) -> bool {
-        match *self {
-            Isbn::_10(ref c) => c.is_valid(),
-            Isbn::_13(ref c) => c.is_valid(),
-        }
-    }
-
     pub fn hyphenate(&self) -> Result<ArrayString<[u8; 17]>, IsbnError> {
         match *self {
             Isbn::_10(ref c) => c.hyphenate(),
@@ -163,11 +155,6 @@ impl Isbn10 {
             .sum();
         let check_digit = (11 - (sum % 11)) % 11;
         check_digit as u8
-    }
-
-    /// Returns `true` if this is a valid ISBN10 code.
-    pub fn is_valid(&self) -> bool {
-        Isbn10::calculate_check_digit(&self.digits) == *self.digits.last().unwrap()
     }
 
     pub fn hyphenate(&self) -> Result<ArrayString<[u8; 17]>, IsbnError> {
@@ -281,11 +268,6 @@ impl Isbn13 {
             .sum();
         let check_digit = (10 - (sum % 10)) % 10;
         check_digit as u8
-    }
-
-    /// Returns `true` if this is a valid ISBN13 code.
-    pub fn is_valid(&self) -> bool {
-        Isbn13::calculate_check_digit(&self.digits) == *self.digits.last().unwrap()
     }
 
     fn ean_ucc_group(&self) -> Result<Group, IsbnError> {


### PR DESCRIPTION
This adds hyphenation support.

ISBN ranges are not parsed at runtime, but converted to code at build time.